### PR TITLE
Logging annotations and turn 180deg

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -33,6 +33,7 @@ class LogWriter:
                 stream_id, len(data)))
         self.f.write(data)
         self.f.flush()
+        return dt
 
     def close(self):
         self.f.close()

--- a/myr2017.py
+++ b/myr2017.py
@@ -171,9 +171,11 @@ def main_replay(filename, force):
 
 
 def play_game(robot, verbose):
-    navigate_row(robot, verbose)
-    move_one_meter(robot)
-    turn_right_90deg(robot)
+    for i in range(10):
+        navigate_row(robot, verbose)
+        move_one_meter(robot)
+        turn_right_90deg(robot)
+        turn_right_90deg(robot)
 
     robot.stop()
     robot.update()

--- a/myr2017.py
+++ b/myr2017.py
@@ -95,9 +95,12 @@ def move_one_meter(robot):
 def turn_right_90deg(robot):
     robot.annot(b'TAG:turn_right_90deg:BEGIN')
     robot.turn_right()
+    gyro_sum = 0
     for i in range(100):
         robot.update()
+        gyro_sum += robot.gyro_raw[2]  # time is required!
     robot.stop()
+    print('gyro_sum', gyro_sum)
     robot.annot(b'TAG:turn_right_90deg:END')
 
 

--- a/myr2017.py
+++ b/myr2017.py
@@ -114,6 +114,25 @@ def turn_right_90deg(robot):
     robot.annot(b'TAG:turn_right_90deg:END')
 
 
+def navigate_row(robot, verbose):
+    robot.move_forward()
+    while True:
+        robot.update()
+        max_dist = max(robot.laser)
+        triplet = laser2ascii(robot.laser)
+        s, left, right = triplet
+        if left < right:
+            robot.move_right()
+        elif left > right:
+            robot.move_left()
+        else:
+            robot.move_forward()
+        if verbose:
+            print('%4d' % max_dist, triplet)
+        if max_dist == 0:
+            break
+
+
 def main(host, port):
     s = None
     for res in socket.getaddrinfo(host, port, socket.AF_UNSPEC, socket.SOCK_STREAM):
@@ -152,28 +171,12 @@ def main_replay(filename, force):
 
 
 def play_game(robot, verbose):
-        robot.move_forward()
-        while True:
-            robot.update()
-            max_dist = max(robot.laser)
-            triplet = laser2ascii(robot.laser)
-            s, left, right = triplet
-            if left < right:
-                robot.move_right()
-            elif left > right:
-                robot.move_left()
-            else:
-                robot.move_forward()
-            if verbose:
-                print('%4d' % max_dist, triplet)
-            if max_dist == 0:
-                break
+    navigate_row(robot, verbose)
+    move_one_meter(robot)
+    turn_right_90deg(robot)
 
-        move_one_meter(robot)
-        turn_right_90deg(robot)
-
-        robot.stop()
-        robot.update()
+    robot.stop()
+    robot.update()
 
 
 if __name__ == '__main__':

--- a/myr2017.py
+++ b/myr2017.py
@@ -81,12 +81,12 @@ def laser2ascii(scan):
     return s, mid-left, right-mid
 
 
-def move_one_meter(robot):
+def move_straight(robot, how_far):
     robot.annot(b'TAG:move_one_meter:BEGIN')
     odo_start = robot.odometry_left_raw + robot.odometry_right_raw
     robot.move_forward()
     dist = 0.0
-    while dist < 1.0:
+    while dist < how_far:
         robot.update()
         odo = robot.odometry_left_raw + robot.odometry_right_raw - odo_start
         dist = 0.06465 * odo / 4.0
@@ -173,8 +173,9 @@ def main_replay(filename, force):
 def play_game(robot, verbose):
     for i in range(10):
         navigate_row(robot, verbose)
-        move_one_meter(robot)
+        move_straight(robot, how_far=1.2)
         turn_right_90deg(robot)
+        move_straight(robot, how_far=0.7)
         turn_right_90deg(robot)
 
     robot.stop()

--- a/myr2017.py
+++ b/myr2017.py
@@ -5,6 +5,7 @@ import socket
 import sys
 import struct
 import itertools
+from datetime import timedelta
 
 from logger import LogWriter, LogReader, LogEnd
 from robot import Robot
@@ -97,14 +98,19 @@ def turn_right_90deg(robot):
     robot.annot(b'TAG:turn_right_90deg:BEGIN')
     robot.turn_right()
     gyro_sum = 0
-    prev_time = robot.time
+    start_time = robot.time
     num_updates = 0
-    for i in range(100):
+    while robot.time - start_time < timedelta(minutes=1):
         robot.update()
         gyro_sum += robot.gyro_raw[2]  # time is required!
         num_updates += 1
+        # the updates are 10Hz (based on laser measurements)
+        angle = (gyro_sum * 0.1) * 30.5/1000.0
+        # also it looks the rotation (in Simulatoz) is clockwise
+        if angle > 90.0:  # TODO lower threshold for minor corrections
+            break
     robot.stop()
-    print('gyro_sum', gyro_sum, robot.time - prev_time, num_updates)
+    print('gyro_sum', gyro_sum, robot.time - start_time, num_updates)
     robot.annot(b'TAG:turn_right_90deg:END')
 
 

--- a/myr2017.py
+++ b/myr2017.py
@@ -85,6 +85,13 @@ def move_one_meter(robot):
     robot.stop()
 
 
+def turn_right_90deg(robot):
+    robot.turn_right()
+    for i in range(100):
+        robot.update()
+    robot.stop()
+
+
 def main(host, port):
     s = None
     for res in socket.getaddrinfo(host, port, socket.AF_UNSPEC, socket.SOCK_STREAM):
@@ -141,6 +148,7 @@ def play_game(robot, verbose):
                 break
 
         move_one_meter(robot)
+        turn_right_90deg(robot)
 
         robot.stop()
         robot.update()

--- a/robot.py
+++ b/robot.py
@@ -9,11 +9,12 @@ LASER_ID = 0x07
 
 
 class Robot:
-    def __init__(self, get, put, term=LASER_ID):
+    def __init__(self, get, put, annot=None, term=LASER_ID):
         "provide input and output methods"
         self.get = get
         self.put = put
         self.term = term
+        self._annot = annot
         
         self.laser = None
         self.odometry_left_raw = 0
@@ -34,6 +35,10 @@ class Robot:
                 break
 
         self.put((MOTOR_ID, self.get_motor_cmd()))
+
+    def annot(self, annotation):
+        'note, that annotation is expected binary bytes'
+        self._annot(annotation)
 
     # Motion Commands
     def move_forward(self):

--- a/robot.py
+++ b/robot.py
@@ -24,10 +24,11 @@ class Robot:
 
         self.motor_pwm = [0, 0]
         self.prev_odo = None
+        self.time = None
 
     def update(self):
         while True:
-            msg_type, data = self.get()
+            self.time, msg_type, data = self.get()
             if msg_type == LASER_ID:
                 self.update_laser(data)
             elif msg_type == ODOMETRY_ID:

--- a/robot.py
+++ b/robot.py
@@ -6,6 +6,7 @@ import struct
 MOTOR_ID = 0x01
 ODOMETRY_ID = 0x06
 LASER_ID = 0x07
+GYRO_ID = 0x0A
 
 
 class Robot:
@@ -19,6 +20,7 @@ class Robot:
         self.laser = None
         self.odometry_left_raw = 0
         self.odometry_right_raw = 0
+        self.gyro_raw = None
 
         self.motor_pwm = [0, 0]
         self.prev_odo = None
@@ -30,6 +32,8 @@ class Robot:
                 self.update_laser(data)
             elif msg_type == ODOMETRY_ID:
                 self.update_odometry(data)
+            elif msg_type == GYRO_ID:
+                self.update_gyro(data)
 
             if msg_type == self.term:
                 break
@@ -72,6 +76,10 @@ class Robot:
             self.odometry_left_raw += diff[2] + diff[3]
         self.prev_odo = data
 
+    def update_gyro(self, data):
+        assert len(data) == 6, len(data)
+        # X, Y, Z (gain factor 30.5)
+        self.gyro_raw = struct.unpack('>hhh', data)
 
     def get_motor_cmd(self):
         return bytes(self.motor_pwm)

--- a/robot.py
+++ b/robot.py
@@ -45,6 +45,12 @@ class Robot:
     def move_right(self):
         self.motor_pwm = [0x70, 0x40]
 
+    def turn_left(self):
+        self.motor_pwm = [0x100-0x70, 0x70]
+
+    def turn_right(self):
+        self.motor_pwm = [0x70, 0x100-0x70]
+
     def stop(self):
         self.motor_pwm = [0, 0]
 

--- a/test_logger.py
+++ b/test_logger.py
@@ -18,9 +18,10 @@ class LoggerTest(unittest.TestCase):
             self.assertTrue(log.filename.startswith('tmpp'))
             filename = log.filename
             start_time = log.start_time
-            log.write(10, b'\x01\x02\x02\x04')
+            t1 = log.write(10, b'\x01\x02\x02\x04')
             time.sleep(0.01)
-            log.write(10, b'\x05\x06\x07\x08')
+            t2 = log.write(10, b'\x05\x06\x07\x08')
+            self.assertLess(t1, t2)
         
         with LogReader(filename) as log:
             self.assertEqual(start_time, log.start_time)

--- a/test_robot.py
+++ b/test_robot.py
@@ -8,7 +8,7 @@ class RoboTest(unittest.TestCase):
     def test_odometry(self):
         q_in = Queue()
         q_out = Queue()
-        robot = Robot(q_in.get, q_out.put, ODOMETRY_ID)
+        robot = Robot(q_in.get, q_out.put, term=ODOMETRY_ID)
 
         q_in.put((ODOMETRY_ID, b'\x00\x00\x00\x00'))
         robot.update()
@@ -23,5 +23,14 @@ class RoboTest(unittest.TestCase):
         self.assertEqual(robot.odometry_left_raw, 0)
         self.assertEqual(robot.odometry_right_raw, 2)
         self.assertEqual(q_out.get(), (MOTOR_ID, b'\x00\x00'))
+
+    def test_annotations(self):
+        q_in = Queue()
+        q_out = Queue()
+        q_annot = Queue()
+        robot = Robot(q_in.get, q_out.put, annot=q_annot.put)
+
+        robot.annot(b'TAG:turn_right_90deg:BEGIN')
+        self.assertEqual(q_annot.get_nowait(), b'TAG:turn_right_90deg:BEGIN')
 
 # vim: expandtab sw=4 ts=4


### PR DESCRIPTION
Another nice side-effect ... I needed to rotate the robot 180 degrees (or 90deg twice) by the end of row, but this maneuver is after whole row, and I wanted to be able to see just this piece of log. Now it is possible, because I reused channel 0 not only for sys.argv dump, but also for "annotations" like `TAG:turn_right_90deg:BEGIN` ...

Again this is rather for info, then for review (as I will have to merge it anyway later today), but comments are welcome.

For Jakub - at the moment it turns too much and destroys the field after first pass ... time for tweaking parameters for turn(??).

p.s. now robots also knows about real time ...