### PR TITLE
Feature/video

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,31 @@ Experiments with Naio robots
 
 Preparation for "Move Your Robot" contest
 https://www.naio-technologies.com/Fira/en/move-your-robot/
+
+![MYR2017](https://robotika.cz/competitions/move-your-robot/2017/world2.jpg)
+
+The development is described in the article on
+https://robotika.cz/competitions/move-your-robot/2017/
+
+## Usage
+
+```
+python3 -h
+usage: myr2017.py [-h] [--host HOST] [--port PORT] [--note NOTE] [--verbose]
+                  [--video-port VIDEO_PORT] [--replay REPLAY] [--force]
+
+Navigate Naio robot in "Move Your Robot" competition
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --host HOST           IP address of the host
+  --port PORT           port number of the robot or simulator
+  --note NOTE           add run description
+  --verbose             show laser output
+  --video-port VIDEO_PORT
+                        optional video port 5558 for simulator, default "no
+                        video"
+  --replay REPLAY       replay existing log file
+  --force, -F           force replay even for failing output asserts
+```
+

--- a/logger.py
+++ b/logger.py
@@ -2,6 +2,7 @@
 
 import datetime
 import struct
+from threading import Lock
 
 
 INFO_STREM_ID = 0
@@ -12,6 +13,7 @@ class LogEnd(Exception):
 
 class LogWriter:
     def __init__(self, prefix='naio', note=''):
+        self.lock = Lock()
         self.start_time = datetime.datetime.now()
         self.filename = prefix + self.start_time.strftime("%y%m%d_%H%M%S.log")
         self.f = open(self.filename, 'wb')
@@ -25,6 +27,7 @@ class LogWriter:
             self.write(stream_id=INFO_STREM_ID, data=bytes(note, encoding='utf-8'))
 
     def write(self, stream_id, data):
+        self.lock.acquire()
         dt = datetime.datetime.now() - self.start_time
         assert dt.days == 0, dt
         assert dt.seconds < 3600, dt  # overflow not supported yet
@@ -33,6 +36,7 @@ class LogWriter:
                 stream_id, len(data)))
         self.f.write(data)
         self.f.flush()
+        self.lock.release()
         return dt
 
     def close(self):

--- a/play_video.py
+++ b/play_video.py
@@ -1,0 +1,51 @@
+"""
+  Play recorded video
+  usage:
+     python play_video.py <log file>
+"""
+
+import sys
+import struct
+import zlib
+
+from logger import LogReader, LogEnd
+
+
+VIDEO_STREAM = 3
+WRAP_SIZE = 6 + 1 + 4 + 4  # NAIO01, type, size + CRC32
+
+
+def play_video(filename):
+    with LogReader(filename) as log:
+        buf = b''
+        num_images = 0
+        while True:
+            try:
+                data = log.read(VIDEO_STREAM)[2]
+            except LogEnd:
+                break
+            buf += zlib.decompress(data)
+            if len(buf) > 10:
+                prefix = buf[:6]
+                assert prefix == b'NAIO01', prefix
+                size = struct.unpack_from('>I', buf, 6+1)[0]
+                if len(buf) >= size + WRAP_SIZE:
+                    image = buf[:size + WRAP_SIZE]
+                    print('image', len(image))
+                    image = image[11+5:-4]  # remove header and CRC32
+                    assert len(image) == 752*480*2, len(image)
+                    f = open('image_%03d.pgm' % num_images, 'wb')
+                    f.write(b'P5\n752 960\n255\n')
+                    f.write(image)
+                    f.close()
+                    num_images += 1
+                    buf = buf[size + WRAP_SIZE:]
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(-1)
+    play_video(sys.argv[1])
+
+# vim: expandtab sw=4 ts=4


### PR DESCRIPTION
Record video in separate VIDEO_STREAM. LogWriter has to have locks now (but time is recorded before lock acquisition*) and the video data (from simulator) are packed by zlib. Traveling 1m with recording without video was 158kB, with uncompressed video 4.2MB and with zlib packed video 2.2MB. This packing could/should be feature of the logger, maybe - but then there need for some flags per stream ... not this project, maybe "later".

Any comments?

p.s. there were actually only 3 images in that 1m navigation ... and I did not try to visualize them yet

(*) this is maybe mistake, because then the order of stored messages does not guarantee order by time - I will add fixup 